### PR TITLE
Add basic React Native todo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ render.experimental.xml
 *.jks
 *.keystore
 
+# Node
+node_modules/
+build/
+
+
 # Google Services (e.g. APIs or Firebase)
 google-services.json
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "todo-mobile-app",
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.72.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.2",
+    "@types/react": "^18.2.14",
+    "@types/react-native": "^0.72.0",
+    "@testing-library/react-native": "^11.5.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.4"
+  },
+  "jest": {
+    "preset": "react-native",
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"]
+  }
+}

--- a/src/TodoApp.tsx
+++ b/src/TodoApp.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { View, TextInput, Text, TouchableOpacity } from 'react-native';
+
+type Todo = {
+  id: string;
+  text: string;
+  completed: boolean;
+};
+
+const createTodo = (text: string): Todo => ({
+  id: Math.random().toString(36).slice(2),
+  text,
+  completed: false,
+});
+
+export const TodoApp: React.FC = () => {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [text, setText] = useState('');
+
+  const handleAdd = () => {
+    if (text.trim().length === 0) return;
+    setTodos([...todos, createTodo(text.trim())]);
+    setText('');
+  };
+
+  const toggleTodo = (id: string) => {
+    setTodos(
+      todos.map((todo: Todo) =>
+        todo.id === id ? { ...todo, completed: !todo.completed } : todo
+      )
+    );
+  };
+
+  const removeTodo = (id: string) => {
+    setTodos(todos.filter((todo: Todo) => todo.id !== id));
+  };
+
+  return (
+    <View>
+      <TextInput
+        placeholder="Add new todo"
+        value={text}
+        onChangeText={setText}
+        onSubmitEditing={handleAdd}
+      />
+      {todos.map((todo) => (
+        <View key={todo.id} style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <TouchableOpacity onPress={() => toggleTodo(todo.id)}>
+            <Text
+              style={{
+                textDecorationLine: todo.completed ? 'line-through' : 'none',
+              }}
+            >
+              {todo.text}
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => removeTodo(todo.id)}>
+            <Text>Delete</Text>
+          </TouchableOpacity>
+        </View>
+      ))}
+    </View>
+  );
+};

--- a/test/TodoApp.test.tsx
+++ b/test/TodoApp.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { TodoApp } from '../src/TodoApp';
+
+describe('TodoApp', () => {
+  it('adds a new todo item', () => {
+    const { getByPlaceholderText, getByText } = render(<TodoApp />);
+
+    const input = getByPlaceholderText('Add new todo');
+    fireEvent.changeText(input, 'Buy milk');
+    fireEvent(input, 'submitEditing');
+
+    expect(getByText('Buy milk')).toBeTruthy();
+  });
+
+  it('toggles a todo as completed', () => {
+    const { getByPlaceholderText, getByText } = render(<TodoApp />);
+
+    const input = getByPlaceholderText('Add new todo');
+    fireEvent.changeText(input, 'Walk dog');
+    fireEvent(input, 'submitEditing');
+
+    const item = getByText('Walk dog');
+    fireEvent.press(item);
+
+    expect(item.props.style.textDecorationLine).toBe('line-through');
+  });
+
+  it('removes a todo item', () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(<TodoApp />);
+
+    const input = getByPlaceholderText('Add new todo');
+    fireEvent.changeText(input, 'Learn TDD');
+    fireEvent(input, 'submitEditing');
+
+    const removeButton = getByText('Delete');
+    fireEvent.press(removeButton);
+
+    expect(queryByText('Learn TDD')).toBeNull();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "build",
+    "jsx": "react",
+    "lib": ["es2019", "dom"]
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up TypeScript project config and jest
- add React Native TodoApp component with add/toggle/delete functionality
- create tests describing expected behaviour
- ignore node_modules and build output

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685f24de345c8333aa6193fac05d23ea