### PR TITLE
Add clear completed todos feature

### DIFF
--- a/src/TodoApp.tsx
+++ b/src/TodoApp.tsx
@@ -35,6 +35,10 @@ export const TodoApp: React.FC = () => {
     setTodos(todos.filter((todo: Todo) => todo.id !== id));
   };
 
+  const clearCompleted = () => {
+    setTodos(todos.filter((todo: Todo) => !todo.completed));
+  };
+
   return (
     <View>
       <TextInput
@@ -43,7 +47,7 @@ export const TodoApp: React.FC = () => {
         onChangeText={setText}
         onSubmitEditing={handleAdd}
       />
-      {todos.map((todo) => (
+      {todos.map((todo: Todo) => (
         <View key={todo.id} style={{ flexDirection: 'row', alignItems: 'center' }}>
           <TouchableOpacity onPress={() => toggleTodo(todo.id)}>
             <Text
@@ -59,6 +63,9 @@ export const TodoApp: React.FC = () => {
           </TouchableOpacity>
         </View>
       ))}
+      <TouchableOpacity onPress={clearCompleted}>
+        <Text>Clear Completed</Text>
+      </TouchableOpacity>
     </View>
   );
 };

--- a/test/TodoApp.test.tsx
+++ b/test/TodoApp.test.tsx
@@ -38,4 +38,24 @@ describe('TodoApp', () => {
 
     expect(queryByText('Learn TDD')).toBeNull();
   });
+
+  it('clears completed todos', () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(<TodoApp />);
+
+    const input = getByPlaceholderText('Add new todo');
+    fireEvent.changeText(input, 'Task 1');
+    fireEvent(input, 'submitEditing');
+
+    fireEvent.changeText(input, 'Task 2');
+    fireEvent(input, 'submitEditing');
+
+    const item1 = getByText('Task 1');
+    fireEvent.press(item1);
+
+    const clearButton = getByText('Clear Completed');
+    fireEvent.press(clearButton);
+
+    expect(queryByText('Task 1')).toBeNull();
+    expect(getByText('Task 2')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- add ability to clear completed todos
- cover the new behaviour with tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f26becc4483339223b0558cde01c1