### PR TITLE
Add todo persistence and deploy automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,5 @@ jobs:
       - run: |
           echo "Building Android app"
           # npx react-native build-android --variant=release
-      - run: |
-          echo "Deploying to App Stores"
-          # fastlane ios release && fastlane android release
+      - run: fastlane ios release
+      - run: fastlane android release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Todo Mobile App
 
 This is a simple React Native todo application used for TDD demonstrations.
+Todos are saved locally using `AsyncStorage` so they persist between sessions.
 
 ## Scripts
 
@@ -10,3 +11,5 @@ This is a simple React Native todo application used for TDD demonstrations.
 ## Continuous Deployment
 
 Pushes to `main` run the GitHub Actions workflow at `.github/workflows/deploy.yml` which installs dependencies, runs tests, builds the app, and triggers placeholder deploy steps.
+
+Fastlane lanes defined in `fastlane/Fastfile` handle building and uploading the iOS and Android apps when invoked.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,17 @@
+default_platform(:ios)
+
+platform :ios do
+  desc 'Build and upload to TestFlight'
+  lane :release do
+    build_ios_app(scheme: 'TodoApp', export_method: 'app-store')
+    upload_to_testflight
+  end
+end
+
+platform :android do
+  desc 'Build and upload to Play Store'
+  lane :release do
+    gradle(task: 'assembleRelease')
+    upload_to_play_store(track: 'internal')
+  end
+end

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-native": "^0.72.0"
+    "react-native": "^0.72.0",
+    "@react-native-async-storage/async-storage": "^1.19.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.2",

--- a/src/TodoApp.tsx
+++ b/src/TodoApp.tsx
@@ -1,11 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, TextInput, Text, TouchableOpacity } from 'react-native';
+import { loadTodos, saveTodos, StoredTodo } from './TodoStorage';
 
-type Todo = {
-  id: string;
-  text: string;
-  completed: boolean;
-};
+type Todo = StoredTodo;
 
 const createTodo = (text: string): Todo => ({
   id: Math.random().toString(36).slice(2),
@@ -19,6 +16,14 @@ export const TodoApp: React.FC = () => {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
   const [filter, setFilter] = useState<'all' | 'active' | 'completed'>('all');
+
+  useEffect(() => {
+    loadTodos().then(setTodos);
+  }, []);
+
+  useEffect(() => {
+    saveTodos(todos);
+  }, [todos]);
 
   const handleAdd = () => {
     if (text.trim().length === 0) return;

--- a/src/TodoStorage.ts
+++ b/src/TodoStorage.ts
@@ -1,0 +1,23 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type StoredTodo = {
+  id: string;
+  text: string;
+  completed: boolean;
+};
+
+const STORAGE_KEY = 'todos';
+
+export const loadTodos = async (): Promise<StoredTodo[]> => {
+  const data = await AsyncStorage.getItem(STORAGE_KEY);
+  if (!data) return [];
+  try {
+    return JSON.parse(data) as StoredTodo[];
+  } catch {
+    return [];
+  }
+};
+
+export const saveTodos = async (todos: StoredTodo[]): Promise<void> => {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(todos));
+};

--- a/test/TodoApp.test.tsx
+++ b/test/TodoApp.test.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
 import { TodoApp } from '../src/TodoApp';
 
 describe('TodoApp', () => {
@@ -110,5 +114,29 @@ describe('TodoApp', () => {
 
     expect(getByText('Task 1')).toBeTruthy();
     expect(getByText('Task 2')).toBeTruthy();
+  });
+
+  it('persists todos between sessions', async () => {
+    jest.resetModules();
+    const mockAsyncStorage = require('@react-native-async-storage/async-storage');
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+
+    const { getByPlaceholderText, getByText, findByText, unmount, rerender } = render(
+      <TodoApp />
+    );
+
+    const input = getByPlaceholderText('Add new todo');
+    fireEvent.changeText(input, 'Persisted');
+    fireEvent(input, 'submitEditing');
+
+    expect(mockAsyncStorage.setItem).toHaveBeenCalled();
+    unmount();
+
+    mockAsyncStorage.getItem.mockResolvedValueOnce(
+      JSON.stringify([{ id: '1', text: 'Persisted', completed: false }])
+    );
+    rerender(<TodoApp />);
+
+    expect(await findByText('Persisted')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- save todos to AsyncStorage so they persist between sessions
- abstract storage logic in `TodoStorage.ts`
- add Fastlane lanes for iOS and Android releases
- trigger Fastlane in deployment workflow
- update tests for persistence and mock AsyncStorage
- document persistence and Fastlane in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685fd152329483339b12151416289eee