### PR TITLE
Feature: show remaining todo count

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 This is a simple React Native todo application used for TDD demonstrations.
 Todos are saved locally using `AsyncStorage` so they persist between sessions.
 
+## Features
+
+- Add, edit and delete todo items
+- Filter todos by status (all, active, completed)
+- Persist todos locally between sessions
+- **New:** shows the count of active todos remaining
+
 ## Scripts
 
 - `npm ci` - install dependencies

--- a/src/TodoApp.tsx
+++ b/src/TodoApp.tsx
@@ -127,6 +127,10 @@ export const TodoApp: React.FC = () => {
       <TouchableOpacity onPress={clearCompleted}>
         <Text>Clear Completed</Text>
       </TouchableOpacity>
+      <Text testID="todo-count">
+        {todos.filter((t) => !t.completed).length}{' '}
+        {todos.filter((t) => !t.completed).length === 1 ? 'item' : 'items'} left
+      </Text>
     </View>
   );
 };

--- a/test/TodoApp.test.tsx
+++ b/test/TodoApp.test.tsx
@@ -138,4 +138,22 @@ describe('TodoApp', () => {
 
     expect(await findByTextAgain('Persisted')).toBeTruthy();
   });
+
+  it('shows the count of active todos', () => {
+    const { getByPlaceholderText, getByText } = render(<TodoApp />);
+
+    const input = getByPlaceholderText('Add new todo');
+    fireEvent.changeText(input, 'Task 1');
+    fireEvent(input, 'submitEditing');
+
+    fireEvent.changeText(input, 'Task 2');
+    fireEvent(input, 'submitEditing');
+
+    expect(getByText('2 items left')).toBeTruthy();
+
+    const item1 = getByText('Task 1');
+    fireEvent.press(item1);
+
+    expect(getByText('1 item left')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- display remaining active todo count in TodoApp
- test active count behavior
- document new feature

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build` *(fails: fastlane not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600ea866f88333ba1af51e2f3fbd1c