### PR TITLE
Feature: add complete-all action

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Todos are saved locally using `AsyncStorage` so they persist between sessions.
 - Filter todos by status (all, active, completed)
 - Persist todos locally between sessions
 - **New:** shows the count of active todos remaining
+- **New:** mark all todos as completed with one tap
 
 ## Scripts
 

--- a/src/TodoApp.tsx
+++ b/src/TodoApp.tsx
@@ -47,6 +47,10 @@ export const TodoApp: React.FC = () => {
     setTodos(todos.filter((todo: Todo) => !todo.completed));
   };
 
+  const completeAll = () => {
+    setTodos(todos.map((todo: Todo) => ({ ...todo, completed: true })));
+  };
+
   const startEdit = (id: string) => {
     const todo = todos.find((t) => t.id === id);
     if (!todo) return;
@@ -124,6 +128,9 @@ export const TodoApp: React.FC = () => {
           )}
         </View>
       ))}
+      <TouchableOpacity onPress={completeAll}>
+        <Text>Complete All</Text>
+      </TouchableOpacity>
       <TouchableOpacity onPress={clearCompleted}>
         <Text>Clear Completed</Text>
       </TouchableOpacity>

--- a/test/TodoApp.test.tsx
+++ b/test/TodoApp.test.tsx
@@ -156,4 +156,25 @@ describe('TodoApp', () => {
 
     expect(getByText('1 item left')).toBeTruthy();
   });
+
+  it('marks all todos as completed', () => {
+    const { getByPlaceholderText, getByText } = render(<TodoApp />);
+
+    const input = getByPlaceholderText('Add new todo');
+    fireEvent.changeText(input, 'Task 1');
+    fireEvent(input, 'submitEditing');
+
+    fireEvent.changeText(input, 'Task 2');
+    fireEvent(input, 'submitEditing');
+
+    const completeAllButton = getByText('Complete All');
+    fireEvent.press(completeAllButton);
+
+    const item1 = getByText('Task 1');
+    const item2 = getByText('Task 2');
+
+    expect(item1.props.style.textDecorationLine).toBe('line-through');
+    expect(item2.props.style.textDecorationLine).toBe('line-through');
+    expect(getByText('0 items left')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- allow completing all todos at once
- document new capability
- test the new behavior

## Codex CI
- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run build` *(fails: fastlane not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860184ad8988333b716cc0886259be8