### PR TITLE
Feature: persist filter preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Todos are saved locally using `AsyncStorage` so they persist between sessions.
 - **New:** shows the count of active todos remaining
 - **New:** mark all todos as completed with one tap
 - **New:** clear all todos at once
+- **New:** remembers your last chosen filter across app restarts
 
 ## Scripts
 

--- a/src/TodoApp.tsx
+++ b/src/TodoApp.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { View, TextInput, Text, TouchableOpacity } from 'react-native';
-import { loadTodos, saveTodos, StoredTodo } from './TodoStorage';
+import {
+  loadTodos,
+  saveTodos,
+  StoredTodo,
+  loadFilter,
+  saveFilter,
+} from './TodoStorage';
 
 type Todo = StoredTodo;
 
@@ -18,12 +24,20 @@ export const TodoApp: React.FC = () => {
   const [filter, setFilter] = useState<'all' | 'active' | 'completed'>('all');
 
   useEffect(() => {
+    loadFilter().then(setFilter);
+  }, []);
+
+  useEffect(() => {
     loadTodos().then(setTodos);
   }, []);
 
   useEffect(() => {
     saveTodos(todos);
   }, [todos]);
+
+  useEffect(() => {
+    saveFilter(filter);
+  }, [filter]);
 
   const handleAdd = () => {
     if (text.trim().length === 0) return;

--- a/src/TodoStorage.ts
+++ b/src/TodoStorage.ts
@@ -7,6 +7,7 @@ export type StoredTodo = {
 };
 
 const STORAGE_KEY = 'todos';
+const FILTER_KEY = 'filter';
 
 export const loadTodos = async (): Promise<StoredTodo[]> => {
   const data = await AsyncStorage.getItem(STORAGE_KEY);
@@ -20,4 +21,18 @@ export const loadTodos = async (): Promise<StoredTodo[]> => {
 
 export const saveTodos = async (todos: StoredTodo[]): Promise<void> => {
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(todos));
+};
+
+export const loadFilter = async (): Promise<'all' | 'active' | 'completed'> => {
+  const value = await AsyncStorage.getItem(FILTER_KEY);
+  if (value === 'active' || value === 'completed') {
+    return value;
+  }
+  return 'all';
+};
+
+export const saveFilter = async (
+  filter: 'all' | 'active' | 'completed'
+): Promise<void> => {
+  await AsyncStorage.setItem(FILTER_KEY, filter);
 };

--- a/test/TodoApp.test.tsx
+++ b/test/TodoApp.test.tsx
@@ -195,4 +195,44 @@ describe('TodoApp', () => {
     expect(queryByText('Task 2')).toBeNull();
     expect(getByText('0 items left')).toBeTruthy();
   });
+
+  it('persists filter between sessions', async () => {
+    const mockAsyncStorage = require('@react-native-async-storage/async-storage');
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+
+    const { getByPlaceholderText, getByText, unmount } = render(<TodoApp />);
+
+    const input = getByPlaceholderText('Add new todo');
+    fireEvent.changeText(input, 'One');
+    fireEvent(input, 'submitEditing');
+
+    fireEvent.changeText(input, 'Two');
+    fireEvent(input, 'submitEditing');
+
+    const itemTwo = getByText('Two');
+    fireEvent.press(itemTwo); // complete second task
+
+    const completedFilter = getByText('Completed');
+    fireEvent.press(completedFilter);
+
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      'filter',
+      'completed'
+    );
+    unmount();
+
+    mockAsyncStorage.getItem.mockResolvedValueOnce('completed');
+    mockAsyncStorage.getItem.mockResolvedValueOnce(
+      JSON.stringify([
+        { id: 'a', text: 'One', completed: false },
+        { id: 'b', text: 'Two', completed: true },
+      ])
+    );
+    const { queryByText: queryByTextAgain, findByText: findByTextAgain } = render(
+      <TodoApp />
+    );
+
+    expect(await findByTextAgain('Two')).toBeTruthy();
+    expect(queryByTextAgain('One')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- store filter state in AsyncStorage
- hydrate filter state on start
- save filter changes
- test filter persistence
- document persistent filter feature

## Codex CI
- `npm ci` ✅
- `npm run build` ❌ (fastlane not found)
- `npm run typecheck` ✅
- `npm test` ✅


------
https://chatgpt.com/codex/tasks/task_e_6860504bebb883339c3ed36ea18de9b1